### PR TITLE
feat: longer poll interval if resource is ready

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -549,7 +550,13 @@ func WithPollInterval(after time.Duration) ReconcilerOption {
 // interval.
 type PollIntervalHook func(managed resource.Managed, pollInterval time.Duration) time.Duration
 
-func defaultPollIntervalHook(_ resource.Managed, pollInterval time.Duration) time.Duration {
+func defaultPollIntervalHook(managed resource.Managed, pollInterval time.Duration) time.Duration {
+	if managed != nil &&
+		managed.GetCondition(xpv1.TypeSynced).Status == v1.ConditionTrue &&
+		managed.GetCondition(xpv1.TypeReady).Status == v1.ConditionTrue {
+		jitter := 30 * time.Minute
+		return time.Hour + time.Duration((rand.Float64()-0.5)*2*float64(jitter)).Round(time.Second)
+	}
 	return pollInterval
 }
 
@@ -1193,9 +1200,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	// changes, so we requeue a speculative reconcile after the specified poll
 	// interval in order to observe it and react accordingly.
 	// https://github.com/crossplane/crossplane/issues/289
-	reconcileAfter := r.pollIntervalHook(managed, r.pollInterval)
-	log.Debug("Successfully requested update of external resource", "requeue-after", time.Now().Add(reconcileAfter))
+	log.Debug("Successfully requested update of external resource", "requeue-after", time.Now().Add(r.pollInterval))
 	record.Event(managed, event.Normal(reasonUpdated, "Successfully requested update of external resource"))
 	managed.SetConditions(xpv1.ReconcileSuccess())
-	return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+	return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 }


### PR DESCRIPTION
I've:
- crossplane-runtime  change from v1.14.0 to v1.16.0 required on https://github.com/OutSystems/cloud-provisioner-aws/pull/76/files
- fetched all tags from crossplane/crossplane-runtime to this repo `git fetch --tags upstream` and `git push --tags`
- created a branch v1.16.0-tag from tag v1.16.0 `git checkout -b v1.16.0-tag v1.16.0`
- created another branch v1.16.0-tag-with-os-changes `git checkout -b v1.16.0-tag-with-os-changes`
- created this PR to get the OS changes from feat/override-default-poll-interval-hook to v1.16.0-tag-with-os-changes

next steps: update the https://github.com/OutSystems/cloud-provisioner-aws/ to point to commit created by this PR.